### PR TITLE
fix build on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,18 @@ find_library(EVENT_LIB
 find_library(EVENT_PTHREAD_LIB
   NAMES event_pthreads
   HINTS "${CMAKE_INSTALL_PREFIX}/lib")
+find_library(EVENT_CORE_LIB
+  NAMES event_core
+  HINTS "${CMAKE_INSTALL_PREFIX}/lib")
+find_library(EVENT_EXTRA_LIB
+  NAMES event_extra
+  HINTS "${CMAKE_INSTALL_PREFIX}/lib")
 find_path(EVENT_INCLUDE_DIR event2/event.h
   PATHS "${CMAKE_INSTALL_PREFIX}/include")
+
 if (EVENT_LIB AND EVENT_PTHREAD_LIB)
   message(STATUS "event-found: " ${EVENT_LIB})
+  message(STATUS "event-core-found: " ${EVENT_CORE_LIB})
   message(STATUS "event-pthread-found: " ${EVENT_PTHREAD_LIB})
   message(STATUS "event-headers-found: " ${EVENT_INCLUDE_DIR})
   include_directories(${EVENT_INCLUDE_DIR})
@@ -73,12 +81,16 @@ elseif (NOT event_FOUND)
     SOURCE_DIR ${LIBEVENT_CMAKE}
     CMAKE_ARGS -DEVENT__DISABLE_DEBUG=ON -DEVENT__DISABLE_BENCHMARK=ON -DEVENT__DISABLE_TESTS=ON -DEVENT__DISABLE_REGRESS=ON -DEVENT__DISABLE_OPENSSL=ON -DEVENT__DISABLE_SAMPLES=ON -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     )
+  set(EVENT_LIB event)
+  set(EVENT_CORE_LIB event_core)
+  set(EVENT_PTHREAD_LIB event_pthreads)
+  set(EVENT_EXTRA_LIB event_extra)
 endif()
 
 # add include and lib dir
 link_directories(${CMAKE_INSTALL_PREFIX}/lib)
 include_directories(${CMAKE_INSTALL_PREFIX}/include
-					${CMAKE_INSTALL_PREFIX}/include/sbf)
+  ${CMAKE_INSTALL_PREFIX}/include/sbf)
 
 # set version info
 set(SBF_MAJOR_VERSION 1)

--- a/examples/publisher/sbfPublisher.c
+++ b/examples/publisher/sbfPublisher.c
@@ -177,7 +177,7 @@ main (int argc, char** argv)
 
     // Initialise the logging system
     log = sbfLog_create (NULL, "%s", "");
-    sbfLog_setLevel (log, SBF_LOG_DEBUG);
+    sbfLog_setLevel (log, SBF_LOG_OFF);
 
     // Apply command options and print message if wrong option is found
     while ((opt = getopt (argc, argv, "h:i:r:s:t:v:")) != -1) {

--- a/examples/publisher/sbfPublisher.c
+++ b/examples/publisher/sbfPublisher.c
@@ -177,7 +177,7 @@ main (int argc, char** argv)
 
     // Initialise the logging system
     log = sbfLog_create (NULL, "%s", "");
-    sbfLog_setLevel (log, SBF_LOG_OFF);
+    sbfLog_setLevel (log, SBF_LOG_DEBUG);
 
     // Apply command options and print message if wrong option is found
     while ((opt = getopt (argc, argv, "h:i:r:s:t:v:")) != -1) {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -47,44 +47,44 @@ set (SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/sbfPool.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/sbfProperties.c")
 
-set (LIBS event_core
-		  event
-		  "${CMAKE_THREAD_LIBS_INIT}"
-		  "${CMAKE_DL_LIBS}")
+set (LIBS ${EVENT_LIB}
+  ${EVENT_CORE_LIB}
+  ${CMAKE_THREAD_LIBS_INIT}
+  ${CMAKE_DL_LIBS})
 
 if(APPLE)
-    set (INSTALL_HEADERS "${INSTALL_HEADERS}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonDarwin.h")
-    set (SOURCES "${SOURCES}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonDarwin.c")
-	set (LIBS "${LIBS}"
-			 	event_pthreads)
+  set (INSTALL_HEADERS "${INSTALL_HEADERS}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonDarwin.h")
+  set (SOURCES "${SOURCES}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonDarwin.c")
+  set (LIBS "${LIBS}"
+    ${EVENT_PTHREAD_LIB})
 elseif(WIN32)
-    set (INSTALL_HEADERS "${INSTALL_HEADERS}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonWin32.h"
-        "${CMAKE_SOURCE_DIR}/src/thirdparty/getopt/getopt.h")
-    set (SOURCES "${SOURCES}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonWin32.c"
-        "${CMAKE_CURRENT_SOURCE_DIR}/fgetln.c"
-        "${CMAKE_CURRENT_SOURCE_DIR}/strlcat.c"
-        "${CMAKE_CURRENT_SOURCE_DIR}/strlcpy.c"
-        "${CMAKE_SOURCE_DIR}/src/thirdparty/getopt/getopt.c")
-	set (LIBS "${LIBS}"
-			 	event_core
-				event_extra
-				Ws2_32.lib
-				Iphlpapi.lib
-				Pathcch.lib)
+  set (INSTALL_HEADERS "${INSTALL_HEADERS}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonWin32.h"
+    "${CMAKE_SOURCE_DIR}/src/thirdparty/getopt/getopt.h")
+  set (SOURCES "${SOURCES}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonWin32.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/fgetln.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strlcat.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strlcpy.c"
+    "${CMAKE_SOURCE_DIR}/src/thirdparty/getopt/getopt.c")
+  set (LIBS "${LIBS}"
+    ${EVENT_CORE_LIB}
+    ${EVENT_EXTRA_LIB}
+    Ws2_32.lib
+    Iphlpapi.lib
+    Pathcch.lib)
 else()
-    set (INSTALL_HEADERS "${INSTALL_HEADERS}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonLinux.h")
-    set (SOURCES "${SOURCES}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonLinux.c"
-        "${CMAKE_CURRENT_SOURCE_DIR}/fgetln.c"
-        "${CMAKE_CURRENT_SOURCE_DIR}/strlcat.c"
-        "${CMAKE_CURRENT_SOURCE_DIR}/strlcpy.c")
-	set (LIBS "${LIBS}"
-			 	event_pthreads)
+  set (INSTALL_HEADERS "${INSTALL_HEADERS}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonLinux.h")
+  set (SOURCES "${SOURCES}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sbfCommonLinux.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/fgetln.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strlcat.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strlcpy.c")
+  set (LIBS "${LIBS}"
+    ${EVENT_PTHREAD_LIB})
 endif()
 
 add_library (sbfcommon SHARED ${SOURCES})

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,20 +14,16 @@ set (SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/sbfTimer.c"
     )
 
-set (LIBS sbfcommon
-          event
-	   	  ${CMAKE_THREAD_LIBS_INIT}
-		  ${CMAKE_DL_LIBS})
-
+set(LIBS sbfcommon ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} ${EVENT_LIB})
 if(WIN32)
-	set (LIBS "${LIBS}"
-			  event_core
-			  event_extra)
+  set (LIBS "${LIBS}"
+    ${EVENT_CORE_LIB}
+    ${EVENT_EXTRA_LIB})
 else()
-	set (LIBS "${LIBS}"
-			  event_pthreads)
+  set (LIBS "${LIBS}"
+    ${EVENT_PTHREAD_LIB})
 endif()
-
+  
 add_library (sbfcore SHARED ${SOURCES})
 target_link_libraries (sbfcore ${LIBS})
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -9,17 +9,18 @@ set (SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/sbfUdpMulticast.c")
 
 set (LIBS sbfcommon
-		  sbfcore
-		  event
-		  ${CMAKE_THREAD_LIBS_INIT}
-		  ${CMAKE_DL_LIBS})
+  sbfcore
+  ${EVENT_LIB}
+  ${CMAKE_THREAD_LIBS_INIT}
+  ${CMAKE_DL_LIBS})
+
 if(WIN32)
-	set (LIBS "${LIBS}"
-			  event_core
-			  event_extra)
+  set (LIBS "${LIBS}"
+    ${EVENT_CORE_LIB}
+    ${EVENT_EXTRA_LIB})
 else()
-	set (LIBS "${LIBS}"
-			  event_pthreads)
+  set (LIBS "${LIBS}"
+    ${EVENT_PTHREAD_LIB})
 endif()
 
 add_library (sbfnetwork SHARED ${SOURCES})
@@ -28,7 +29,6 @@ target_link_libraries (sbfnetwork ${LIBS})
 if (NOT EVENT_LIB)
     add_dependencies (sbfnetwork libevent)
 endif()
-
 
 install (TARGETS sbfnetwork
          EXPORT sbfnetwork


### PR DESCRIPTION
Also turned on debug logging for example as it crashed failing to create transport. Turning on debug logging shows the interface eth0 doesnt exist. So running with interface set to lo0 for mac loopback works.

```
2019-04-03 13:56:03.182640 INFO  this is version 0.0.2
2019-04-03 13:56:03.183036 DEBUG creating middleware 0x7fea77700150, using 1 threads
2019-04-03 13:56:03.183415 DEBUG thread 0 entered
2019-04-03 13:56:03.183678 DEBUG creating queue 0x7fea777002f0
2019-04-03 13:56:03.183762 DEBUG queue 0x7fea777002f0 entered
2019-04-03 13:56:03.183775 DEBUG creating transport 0x7fea77600480: name default
2019-04-03 13:56:03.191251 DEBUG trying handler udp
2019-04-03 13:56:03.191475 INFO  loading udp transport handler (from libsbfudphandler.dylib)
2019-04-03 13:56:03.195179 DEBUG interface lo0 is 127.0.0.1
2019-04-03 13:56:03.195198 DEBUG interface en0 is 10.12.1.219
2019-04-03 13:56:03.195203 DEBUG interface gpd0 is 10.25.20.72
2019-04-03 13:56:03.195229 ERROR couldn't get interface: eth0
2019-04-03 13:56:03.195233 ERROR handler udp create function failed
2019-04-03 13:56:03.195236 ERROR no handlers available, tried udp
2019-04-03 13:56:03.195272 DEBUG creating timer 0x7fea77402870: interval 1.000 seconds
Segmentation fault: 11```