### PR TITLE
sbfTimer changes

### DIFF
--- a/src/core/sbfTimer.c
+++ b/src/core/sbfTimer.c
@@ -27,12 +27,18 @@ sbfTimerEventCb (int fd, short events, void* closure)
     }
 }
 
+void
+sbfTimer_enable (sbfTimer timer)
+{
+    event_add (&timer->mEvent, &timer->mTime);
+}
+
 sbfTimer
-sbfTimer_create (sbfMwThread thread,
-                 sbfQueue queue,
-                 sbfTimerCb cb,
-                 void* closure,
-                 double interval)
+sbfTimer_create_disabled (sbfMwThread thread,
+                          sbfQueue queue,
+                          sbfTimerCb cb,
+                          void* closure,
+                          double interval)
 {
     sbfTimer timer;
 
@@ -63,7 +69,22 @@ sbfTimer_create (sbfMwThread thread,
                   0,
                   sbfTimerEventCb,
                   timer);
-    event_add (&timer->mEvent, &timer->mTime);
+
+    return timer;
+}
+
+sbfTimer
+sbfTimer_create (sbfMwThread thread,
+                 sbfQueue queue,
+                 sbfTimerCb cb,
+                 void* closure,
+                 double interval)
+{
+    sbfTimer timer;
+
+    timer = sbfTimer_create_disabled (thread, queue, cb, closure, interval);
+
+    sbfTimer_enable (timer);
 
     return timer;
 }

--- a/src/core/sbfTimer.h
+++ b/src/core/sbfTimer.h
@@ -31,6 +31,29 @@ typedef void (*sbfTimerCb) (sbfTimer timer, void* closure);
 #define SBF_TIMER_MICROSECONDS(n) ((n)/1000000.0)
 
 /*!
+ \brief Enable a timer that was created with sbfTimer_create_disabled
+ \param timer the timer handler.
+*/
+void sbfTimer_enable (sbfTimer timer);
+
+/*!
+   \brief Create a timer with the given arguments which can be enabled later.
+   \param thread the thread handler.
+   \param queue a queue.
+   \param cb High resolution timer callback. It will be invoked when the
+   timer expires.
+   \param closure user data associated to this high resolution timer.
+   \param interval the interval, in seconds, the timer is configured to fire
+    the callback.
+   \return a timer handler.
+*/
+sbfTimer sbfTimer_create_disabled (struct sbfMwThreadImpl* thread,
+                                   struct sbfQueueImpl* queue,
+                                   sbfTimerCb cb,
+                                   void* closure,
+                                   double interval);
+
+/*!
    \brief Create a timer with the given arguments.
    \param thread the thread handler.
    \param queue a queue.


### PR DESCRIPTION
Add a `sbfTimer_create_disabled` function to create an sbfTimer but not
have it fire until some later time, which can now be controlled with
another new `sbfTimer_enable` function.