### PR TITLE
TCP connection/listener fixes

### DIFF
--- a/src/handlers/tcpmesh/sbfTcpMeshHandler.c
+++ b/src/handlers/tcpmesh/sbfTcpMeshHandler.c
@@ -274,7 +274,7 @@ sbfTcpMeshHandlerCreate (sbfTport tport, sbfKeyValue properties)
         if (tmh->mListener == NULL)
         {
             sbfLog_err (tmh->mLog,
-                        "failed to create listener for port %u: %s",
+                        "failed to create listener for port %lu: %s",
                         port, strerror (errno));
             goto fail;
         }

--- a/src/network/sbfTcpConnection.c
+++ b/src/network/sbfTcpConnection.c
@@ -290,8 +290,8 @@ sbfTcpConnection_destroy (sbfTcpConnection tc)
 
     tc->mDestroyed = 1;
     EVUTIL_CLOSESOCKET (tc->mSocket);
-
-    bufferevent_free (tc->mEvent);
+    if (tc->mEvent != NULL)
+        bufferevent_free (tc->mEvent);
 
     if (sbfRefCount_decrement (&tc->mRefCount))
         free (tc);

--- a/src/network/sbfTcpConnection.c
+++ b/src/network/sbfTcpConnection.c
@@ -126,10 +126,6 @@ sbfTcpConnectionEventEventCb (struct bufferevent* bev,
 
     if (events & (BEV_EVENT_ERROR|BEV_EVENT_TIMEOUT|BEV_EVENT_EOF))
     {
-        if (tc->mEvent != NULL)
-            bufferevent_free (tc->mEvent);
-        tc->mEvent = NULL;
-
         sbfRefCount_increment (&tc->mRefCount);
         sbfQueue_enqueue (tc->mQueue, sbfTcpConnectionErrorQueueCb, tc);
         return;
@@ -294,8 +290,8 @@ sbfTcpConnection_destroy (sbfTcpConnection tc)
 
     tc->mDestroyed = 1;
     EVUTIL_CLOSESOCKET (tc->mSocket);
-    if (tc->mEvent != NULL)
-        bufferevent_free (tc->mEvent);
+
+    bufferevent_free (tc->mEvent);
 
     if (sbfRefCount_decrement (&tc->mRefCount))
         free (tc);

--- a/src/network/sbfTcpListener.c
+++ b/src/network/sbfTcpListener.c
@@ -24,6 +24,8 @@ sbfTcpListenerAcceptQueueCb (sbfQueueItem item, void* closure)
 
     if (!tl->mDestroyed)
         tl->mAcceptCb (tl, tc, tl->mClosure);
+    else
+        sbfTcpConnection_destroy (tc);
 
     if (sbfRefCount_decrement (&tl->mRefCount))
         free (tl);


### PR DESCRIPTION
No longer call bufferevent_free in the libevent event callback if
there's an error/timeout/eof event from libevent in sbfTcpConnection.
This was causing double free/use after free if we destroyed the tcp
connection on the queue at the same time as this libevent callback ran.

Now in the sbfTcpListener, if we destroy the listener between the point
when we enqueue an event to say we've accepted a new connection and this
enqueued event firing, we free the connection; otherwise it would leak
as we wouldn't call the accept callback due to destroying the listener.