### PR TITLE
Bugfix/tcp fixes

### DIFF
--- a/src/network/sbfTcpConnection.c
+++ b/src/network/sbfTcpConnection.c
@@ -66,12 +66,13 @@ static void
 sbfTcpConnectionReadQueueCb (sbfQueueItem item, void* closure)
 {
     sbfTcpConnection tc = closure;
-    struct evbuffer* evb = bufferevent_get_input (tc->mEvent);
+    struct evbuffer* evb;
     size_t           size;
     size_t           used;
 
     if (!tc->mDestroyed)
     {
+        evb = bufferevent_get_input (tc->mEvent);
         size = evbuffer_get_length (evb);
         if (size != 0)
         {

--- a/src/network/sbfTcpListener.c
+++ b/src/network/sbfTcpListener.c
@@ -25,7 +25,7 @@ sbfTcpListenerAcceptQueueCb (sbfQueueItem item, void* closure)
     if (!tl->mDestroyed)
         tl->mAcceptCb (tl, tc, tl->mClosure);
     else
-        sbfTcpConnection_destroy (tc);
+        free (tc); /* _wrap doesn't init refcount, so just free here */
 
     if (sbfRefCount_decrement (&tl->mRefCount))
         free (tl);


### PR DESCRIPTION
Now call bufferevent_get_input after the mDestroyed check in the read queue cb
for sbfTcpConnection, else sometimes we'd use the mEvent after freeing it.

Now free the sbfTcpConnection if the sbfTcpListener has been destroyed, rather
than using sbfTcpConnection_destroy, as the ref count won't have been
initialised in this scenario.